### PR TITLE
Add a context field to logging

### DIFF
--- a/src/LogMetaData.ts
+++ b/src/LogMetaData.ts
@@ -7,6 +7,7 @@ interface LogMetaData {
     event?: string;
     status?: number;
     duration?: number;
+    context?: string;
 }
 
 export = LogMetaData;

--- a/src/formatting/HumanFormatFactory.ts
+++ b/src/formatting/HumanFormatFactory.ts
@@ -14,6 +14,7 @@ class HumanFormatFactory {
                 created: moment().format("YYYY-MM-DDTHH:mm:ss.SSSZ"),
                 namespace: namespace,
                 event: info.level,
+                context: info.context,
                 path: info.path,
                 method: info.method,
                 status: info.status,

--- a/src/formatting/JsonFormatFactory.ts
+++ b/src/formatting/JsonFormatFactory.ts
@@ -13,6 +13,7 @@ class JsonFormatFactory {
                 namespace: namespace,
                 data: {
                     message: info.message,
+                    context: info.context,
                     path: info.path,
                     method: info.method,
                     status: info.status,

--- a/src/getRequestMetaData.ts
+++ b/src/getRequestMetaData.ts
@@ -5,7 +5,8 @@ const getRequestMetaData = function (request: Request): LogMetaData {
 
     return {
         path: request.path,
-        method: request.method
+        method: request.method,
+        context: request.headers['context'] === undefined ? undefined : request.headers['context'].toString()
     };
 };
 


### PR DESCRIPTION
There is no context field as there is in structure logging for java which allows a context to be added so that log messages can be grouped together.
Add context field to LogMetaData.ts
Set the context in getRequestMetaData.ts
Update HumanFormatFactory.ts to include the context field
Update JsonFormatFactory.ts to include the context field

BI-12146