### PR TITLE
ASM-1574 - Fix for ScannerEngine not finding coverage/lcov.info

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,4 +3,4 @@ sonar.sources=src
 sonar.exclusions=**/bin/**, **/dist/**, **/coverage/**, **/node_modules/**
 sonar.tests=test
 sonar.test.inclusions=**/test/**.test.*
-sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.typescript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
[INFO]  ScannerEngine: No LCOV files were found using coverage/lcov.info
